### PR TITLE
read from provided FIFO

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +53,7 @@ dependencies = [
 name = "client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "structopt",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 structopt = "0.3.26"
+anyhow = "1"

--- a/client/src/args.rs
+++ b/client/src/args.rs
@@ -1,14 +1,20 @@
+use std::path::PathBuf;
+
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
-enum Command {
-    Chat {},
+pub enum Opts {
+    Chat {
+        /// path of the FIFO (named unix pipe file) through which the client and daemon will be
+        /// communicating.
+        // TODO: have a default value for this once the client-daemon protocol is more fleshed out.
+        #[structopt(short, long)]
+        fifo: PathBuf,
+    },
 }
 
-pub fn parse_args() {
-    match Command::from_args() {
-        Command::Chat {} => {
-            println!("Chat!");
-        }
+impl Opts {
+    pub fn get() -> Self {
+        Self::from_args()
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,7 +1,25 @@
-use args::parse_args;
+use std::{
+    fs::{self},
+    os::unix::prelude::FileTypeExt,
+};
+
+use anyhow::{bail, Context, Result};
+use args::Opts;
 
 pub mod args;
 
-fn main() {
-    parse_args();
+fn main() -> Result<()> {
+    match Opts::get() {
+        Opts::Chat { fifo } => {
+            let metadata = fs::metadata(&fifo).context("couldn't get metadata of fifo")?;
+            if !metadata.file_type().is_fifo() {
+                bail!("{fifo:?} is not a fifo");
+            }
+
+            loop {
+                let bytes = fs::read(&fifo).context("couldn't read fifo")?;
+                println!("got message: {:02x?}", bytes);
+            }
+        }
+    }
 }


### PR DESCRIPTION
the client now continuously reads from a FIFO (named unix pipe) file provided via command line argument (there should be a default location at some point) and prints out the bytes recieved in each message.