### PR TITLE
Improve error handling for contact parsing

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,6 @@
 use reqwest;
 
-use common::structures::{DiscoveryRequest, DiscoveryResponse, Status};
+use common::structures::{DiscoveryRequest, DiscoveryResponse};
 use discovery::{discover, discover_root, DiscoveryServerConfig};
 use std::net::{IpAddr, Ipv4Addr};
 


### PR DESCRIPTION
Creates a new ContactParseError struct which returns upon a failed parse of a DaemonResponse into a Contact object.