### PR TITLE
Remove expired adverts

### DIFF
--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -16,7 +16,7 @@ impl Cleanable for DiscoveryQueue {
         match self.queue.try_read().map_err(|e| CleanError::LockError) {
             Ok(it) => {
                 for ele in it.values() {
-                    SystemTime::now().checked_add(Duration::from_millis(ele.expires_in));
+                    SystemTime::now().checked_add(ele.expires_in);
                 }
             }
             Err(err) => return Err(err),

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -23,6 +23,7 @@ impl Cleanable for DiscoveryQueue {
                             // Ok signifies that the duration since the specified time was
                             // positive, therefor the advertisement is expired
                             to_remove.push(ele.0.to_string());
+                            println!("Removing request by {}", ele.1.discovery.requested_by);
                         }
                         Err(_) => {
                             // The advertisement is not expired yet
@@ -40,5 +41,45 @@ impl Cleanable for DiscoveryQueue {
                 .remove(ele);
         }
         Ok(to_remove.len())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::HashMap,
+        net::{IpAddr, Ipv4Addr},
+        sync::RwLock,
+        time::{Duration, SystemTime},
+    };
+
+    use common::structures::DiscoveryRequest;
+
+    use crate::discovery::{Advertisement, DiscoveryQueue};
+
+    #[test]
+    fn clean_test() {
+        let discoveryqueue = DiscoveryQueue {
+            queue: RwLock::new(HashMap::new()),
+        };
+
+        let mut locked_queue = discoveryqueue.queue.write().unwrap();
+
+        let disc_req_a = DiscoveryRequest {
+            ip: Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            port: 2121,
+            requested_by: "A".to_string(),
+            looking_for: "B".to_string(),
+            public_key: "qwertyuiop".to_string(),
+        };
+
+        locked_queue.insert(
+            "A".to_string(),
+            Advertisement {
+                discovery: disc_req_a,
+                created_at: SystemTime::now(),
+                expires_in: Duration::from_millis(100),
+            },
+        );
     }
 }

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -7,13 +7,12 @@ pub enum CleanError {
 }
 
 pub trait Cleanable {
-    // Returns the amount of instances that have been cleaned from the queue
+    /// Cleans each advertisement based on it's age and expiration date
+    /// Returns the number of advertisements removed
     fn clean(&self) -> Result<usize, CleanError>;
 }
 
 impl Cleanable for DiscoveryQueue {
-    /// Cleans each advertisement based on it's age and expiration date
-    /// Returns the number of advertisements removed
     fn clean(&self) -> Result<usize, CleanError> {
         let mut to_remove: Vec<String> = vec![];
         match self.queue.try_read().map_err(|_| CleanError::LockError) {

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -8,11 +8,13 @@ pub enum CleanError {
 
 pub trait Cleanable {
     // Returns the amount of instances that have been cleaned from the queue
-    fn clean(&self) -> Result<u16, CleanError>;
+    fn clean(&self) -> Result<usize, CleanError>;
 }
 
 impl Cleanable for DiscoveryQueue {
-    fn clean(&self) -> Result<u16, CleanError> {
+    /// Cleans each advertisement based on it's age and expiration date
+    /// Returns the number of advertisements removed
+    fn clean(&self) -> Result<usize, CleanError> {
         let mut to_remove: Vec<String> = vec![];
         match self.queue.try_read().map_err(|_| CleanError::LockError) {
             Ok(it) => {
@@ -38,16 +40,6 @@ impl Cleanable for DiscoveryQueue {
                 .map_err(|_| CleanError::LockError)?
                 .remove(ele);
         }
-        Ok(to_remove
-            .len()
-            .try_into()
-            .expect("Length of removed items was not expected to be so long")) // This can only
-                                                                               // fail if the
-                                                                               // unsigned value of
-                                                                               // the number of
-                                                                               // advertisements
-                                                                               // removed exceeds
-                                                                               // the 16 bit
-                                                                               // integer limit
+        Ok(to_remove.len())
     }
 }

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -1,0 +1,26 @@
+use std::time::{Duration, SystemTime};
+
+use crate::discovery::DiscoveryQueue;
+
+pub enum CleanError {
+    LockError,
+}
+
+pub trait Cleanable {
+    // Returns the amount of instances that have been cleaned from the queue
+    fn clean(&self) -> Result<u16, CleanError>;
+}
+
+impl Cleanable for DiscoveryQueue {
+    fn clean(&self) -> Result<u16, CleanError> {
+        match self.queue.try_read().map_err(|e| CleanError::LockError) {
+            Ok(it) => {
+                for ele in it.values() {
+                    SystemTime::now().checked_add(Duration::from_millis(ele.expires_in));
+                }
+            }
+            Err(err) => return Err(err),
+        };
+        Ok(0)
+    }
+}

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use crate::discovery::DiscoveryQueue;
 
@@ -13,14 +13,31 @@ pub trait Cleanable {
 
 impl Cleanable for DiscoveryQueue {
     fn clean(&self) -> Result<u16, CleanError> {
-        match self.queue.try_read().map_err(|e| CleanError::LockError) {
+        let mut to_remove: Vec<String> = vec![];
+        match self.queue.try_read().map_err(|_| CleanError::LockError) {
             Ok(it) => {
-                for ele in it.values() {
-                    SystemTime::now().checked_add(ele.expires_in);
+                for ele in it.iter() {
+                    match SystemTime::now().duration_since(ele.1.created_at + ele.1.expires_in) {
+                        Ok(_) => {
+                            // Ok signifies that the duration since the specified time was
+                            // positive, therefor the advertisement is expired
+                            to_remove.push(ele.0.to_string());
+                        }
+                        Err(_) => {
+                            // The advertisement is not expired yet
+                        }
+                    }
                 }
             }
             Err(err) => return Err(err),
         };
-        Ok(0)
+
+        for ele in &to_remove {
+            self.queue.write().expect("").remove(ele);
+        }
+        Ok(to_remove
+            .len()
+            .try_into()
+            .expect("Length of removed items was not expected to be so long"))
     }
 }

--- a/server/src/cleanable.rs
+++ b/server/src/cleanable.rs
@@ -33,11 +33,21 @@ impl Cleanable for DiscoveryQueue {
         };
 
         for ele in &to_remove {
-            self.queue.write().expect("").remove(ele);
+            self.queue
+                .try_write()
+                .map_err(|_| CleanError::LockError)?
+                .remove(ele);
         }
         Ok(to_remove
             .len()
             .try_into()
-            .expect("Length of removed items was not expected to be so long"))
+            .expect("Length of removed items was not expected to be so long")) // This can only
+                                                                               // fail if the
+                                                                               // unsigned value of
+                                                                               // the number of
+                                                                               // advertisements
+                                                                               // removed exceeds
+                                                                               // the 16 bit
+                                                                               // integer limit
     }
 }

--- a/server/src/discovery.rs
+++ b/server/src/discovery.rs
@@ -1,7 +1,7 @@
 use super::structures::DiscoveryRequest;
 use std::collections::HashMap;
 use std::sync::RwLock;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 /// Represents an Advertisement that is saved for a certain period of time.
 #[derive(Debug)]
@@ -11,7 +11,7 @@ pub struct Advertisement {
     /// The time the Advertisement was created
     pub created_at: SystemTime,
     /// How long until the Advertisement expires
-    pub expires_in: u64,
+    pub expires_in: Duration,
 }
 
 /// Manages the state of the application for persisting Advertisements

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate rocket;
 
+pub mod cleanable;
 pub mod discovery;
 pub mod routes;
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -4,7 +4,7 @@ use log::debug;
 use rocket::serde::json::Json;
 use rocket::State;
 use std::net::SocketAddr;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[get("/")]
 fn home() -> String {
@@ -37,7 +37,7 @@ fn discover(
     let advert = Advertisement {
         discovery: discoveryrequest.clone().into_inner(),
         created_at: SystemTime::now(),
-        expires_in: 5000,
+        expires_in: Duration::from_millis(5000),
     };
     debug!("{:?}", &advert);
     discoveryqueue


### PR DESCRIPTION
- Adds a `Cleanable` trait and implements it for `DiscoveryQueue`
- Adds a test to ensure that only the expired advertisements are getting removed
- Does **not** yet call the `clean` method in normal operation